### PR TITLE
gitlab-ci.yml: update deprecated build variables.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
 build:
   # https://docs.gitlab.com/ee/ci/yaml/#cache
   cache:
-    key: "$CI_BUILD_NAME"
+    key: "$CI_JOB_NAME"
     paths:
       - .stack-work/
       - .stack-root/
@@ -29,7 +29,7 @@ build:
 
 test:
   cache:
-    key: "$CI_BUILD_NAME"
+    key: "$CI_JOB_NAME"
     paths:
       - .stack-work/
       - .stack-root/


### PR DESCRIPTION
As documented in https://docs.gitlab.com/ee/ci/variables/README.html

"Note: Starting with GitLab 9.0, we have deprecated the $CI_BUILD_* variables.
You are strongly advised to use the new variables as we will remove the old ones 
in future GitLab releases."